### PR TITLE
Fix deployment config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,10 +22,18 @@ jobs:
           key: branch-manager-{{ checksum "yarn.lock" }}
           paths:
             - ~/.yarn-cache
+      - deploy:
+          name: Publish to NPM if tagged
+          command: |
+            set -euo pipefail
+            TAG=${CIRCLE_TAG:-}
+            if [[ ${TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+              npm publish
+            else
+              echo "Not publishing: build was not triggered by a proper release tag"
+            fi
 
 deployment:
   npm:
-    tag: /[0-9]+\.[0-9]+\.[0-9]+/
-    commands:
-      - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - cd build && npm publish
+    tag: /^[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
CircleCI 2.0 does not support commands in the top-level deployment
object. It is only used as a workaround for now to allow tags to trigger
builds. Deployment-related commands still need to be part of the `steps`
list.