### PR TITLE
Automate package.json versioning as part of build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,7 @@ jobs:
             set -euo pipefail
             TAG=${CIRCLE_TAG:-}
             if [[ ${TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              yarn version --new-version "$TAG" --no-git-tag-version
               echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
               npm publish
             else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-manager",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "description": "Manage your branches on Github",
   "main": "./dist/main.js",
   "repository": "https://github.com/michael-yx-wu/branch-manager",


### PR DESCRIPTION
The package.json's version field is now 0.0.0. Installing branch-manager
from the build folder will now always tell you that you're running
0.0.0. The version has to be parseable by node-semver so it can't be
something be readable like "develop". On builds triggered by a tags that
match [0-9]+\.[0-9]+\.[0-9]+, the version is automatically updated in
the build/package.json to reflect the tag.