### PR TITLE
Fix paging infinite loop

### DIFF
--- a/src/branch-manager/branchManager.ts
+++ b/src/branch-manager/branchManager.ts
@@ -156,7 +156,7 @@ export class BranchManager {
         if (protectedBranchesOnly) {
             uri = uri.concat("?protected=true");
         }
-        const requestOptions = this.getDefaultRequestOptions(uri);
+        let requestOptions = this.getDefaultRequestOptions(uri);
         let branches: IBranch[] = [];
         do {
             this.logger.debug(`GET ${uri}`);
@@ -171,6 +171,9 @@ export class BranchManager {
                 }
                 this.logger.debug(`Got link header: ${maybeLinkHeader}`);
                 uri = this.getNextLink(maybeLinkHeader as string);
+                if (uri !== undefined) {
+                    requestOptions = this.getDefaultRequestOptions(uri);
+                }
             } catch (error) {
                 throw error;
             }


### PR DESCRIPTION
Previously would BranchManager would correctly parse the link header but
fail to update the request options object, resulting in an infinite loop
when a next link is present.